### PR TITLE
Pull Request to add support of synchronize module

### DIFF
--- a/hosts.ini
+++ b/hosts.ini
@@ -26,13 +26,13 @@ junos_package= "jinstall-ex-2200-12.3R3.4-domestic.tgz"
 ########################
 
 [ztp-servers]
-ztp01       ansible_host=10.73.1.196
+ztp01       ansible_host=10.73.1.200
 
 [ztp-servers:vars]
 ansible_connection=ssh
 ansible_ssh_user=ansible
-ansible_ssh_pass='password123'
-ansible_sudo_pass='password123'
+ansible_ssh_pass='interdata'
+ansible_sudo_pass='interdata'
 
 [ansible-servers]
 ansible01       ansible_host=127.0.0.1

--- a/playbook-ztp-push-data.yml
+++ b/playbook-ztp-push-data.yml
@@ -4,5 +4,7 @@
     hosts: ztp-servers
     connection: ssh
     gather_facts: no
+    vars:
+        sync: true
     roles:
       - {role: ztp-push-dhcp, become: yes}

--- a/roles/ztp-install-packages/tasks/main.yaml
+++ b/roles/ztp-install-packages/tasks/main.yaml
@@ -8,6 +8,9 @@
 - name: install DHCP server
   apt: name=isc-dhcp-server state=present
 
+- name: install RSYNC service
+  apt: name=rsync state=present
+
 - name: Push dhcpd.conf template
   template: src={{role_path}}/templates/dhcp.j2 dest=/etc/dhcp/dhcpd.conf owner=root group=root mode=0644
 
@@ -34,3 +37,10 @@
 
 - name: restart ftp service to apply changes
   service: name=vsftpd state=restarted
+
+- name: get rsync path
+  shell: which rsync
+  register: rsync_path
+
+- name: setup sudo to use rsync with no-password
+  lineinfile: dest=/etc/sudoers line="{{ansible_ssh_user}} ALL=NOPASSWD:/usr/bin/rsync"

--- a/roles/ztp-push-dhcp/tasks/main.yaml
+++ b/roles/ztp-push-dhcp/tasks/main.yaml
@@ -5,10 +5,18 @@
 - name: Restart dhcp service to apply changes
   service: name=isc-dhcp-server state=restarted
 
+
+- name: Push junos configuration to the FTP server with sync
+  synchronize: src={{ztp.path.junos_local}}/ dest={{ztp.path.ftp_root}}/{{ztp.path.ftp_conf}}/ recursive=no rsync_path="sudo rsync"
+  when:
+    - sync == true
+
 - name: Push junos configuration to the FTP server
   copy: src={{ item }} dest={{ztp.path.ftp_root}}/{{ztp.path.ftp_conf}}/{{ item | basename  }}
   with_fileglob:
         - "{{ztp.path.junos_local}}/*.conf"
+  when:
+    - sync == false
 
 - name: Push junos softwares to the FTP server
   copy: src={{ item }} dest={{ztp.path.ftp_root}}/{{ztp.path.soft}}/{{ item | basename  }}


### PR DESCRIPTION
Pull Request to enable support of `synchronize` module to move all configuration files from ansible server to FTP server

Managed by issue #31 

Move to `dev` before moving to `master` when v1.1 will be completed