### PR TITLE
dhcp service restart change

### DIFF
--- a/roles/ztp-push-dhcp/tasks/main.yaml
+++ b/roles/ztp-push-dhcp/tasks/main.yaml
@@ -1,10 +1,4 @@
 ---
-- name: Copy dhcp content to dhcp-server
-  template: src={{ build_dir }}/dhcpd.conf dest=/etc/dhcp/dhcpd.conf backup=yes
-
-- name: Restart dhcp service to apply changes
-  service: name=isc-dhcp-server state=restarted
-
 - name: Push junos configuration to the FTP server
   copy: src={{ item }} dest={{ztp.path.ftp_root}}/{{ztp.path.ftp_conf}}/{{ item | basename  }}
   with_fileglob:
@@ -14,3 +8,11 @@
   copy: src={{ item }} dest={{ztp.path.ftp_root}}/{{ztp.path.soft}}/{{ item | basename  }}
   with_fileglob:
         - "{{ztp.path.software_local}}/*"
+
+- name: Copy dhcp content to dhcp-server
+  template: src={{ build_dir }}/dhcpd.conf dest=/etc/dhcp/dhcpd.conf backup=yes
+  register: dhcp_config
+
+- name: Restart dhcp service to apply changes
+  service: name=isc-dhcp-server state=restarted
+  when: dhcp_config.changed


### PR DESCRIPTION
added register dhcp_config to only restart the dhcp service if config changed.
also moved the dhcp copy and restart to the bottom because in a really really unrealistic scenario the ftp cant serve files which the dhcp server is announcing.